### PR TITLE
Fix incorrect sound file references

### DIFF
--- a/sound/CC-Sounds/close_door/door_fence/close_door.json
+++ b/sound/CC-Sounds/close_door/door_fence/close_door.json
@@ -4,6 +4,6 @@
     "id": "close_door",
     "variant" : " t_chaingate_c ",
     "volume": 100,
-    "files": [ "open_door/door_fence/close_door_fence.ogg" ]
+    "files": [ "close_door/door_fence/close_door_fence.ogg" ]
   }
 ]

--- a/sound/CC-Sounds/close_door/window/close_window.json
+++ b/sound/CC-Sounds/close_door/window/close_window.json
@@ -11,7 +11,7 @@
         "id" : "close_door",
         "variant" : "t_window_domestic",
         "volume" : 100,
-        "files" : [ "close_door/window/close_curtains.ogg" ]
+        "files" : [ "close_door/window/close_curtain.ogg" ]
     },
     {
         "type": "sound_effect",

--- a/sound/CC-Sounds/engine_start/v8/engine_start_v8.json
+++ b/sound/CC-Sounds/engine_start/v8/engine_start_v8.json
@@ -3,5 +3,5 @@
     "id": "engine_start",
     "variant": "engine_v8",
     "volume": 100,
-    "files": [ "engine_start/combustion/engine_start_v8.ogg" ]
+    "files": [ "engine_start/v8/engine_start_v8.ogg" ]
 }

--- a/sound/CC-Sounds/open_door/window/open_window.json
+++ b/sound/CC-Sounds/open_door/window/open_window.json
@@ -18,6 +18,6 @@
         "id" : "open_door",
         "variant" : "t_curtains",
         "volume" : 80,
-        "files" : [ "open_door/window/open_curtains.ogg" ]
+        "files" : [ "open_door/window/open_curtain.ogg" ]
     }
 ]

--- a/sound/CC-Sounds/plmove/plmove.json
+++ b/sound/CC-Sounds/plmove/plmove.json
@@ -59,7 +59,6 @@
       "plmove/walk_t_concrete_6.ogg",
       "plmove/walk_t_concrete_7.ogg",
       "plmove/walk_t_concrete_8.ogg",
-      "plmove/walk_t_concrete_9.ogg",
       "plmove/walk_t_concrete_10.ogg"
     ]
   },

--- a/sound/CC-Sounds/vehicle_close/v_curtain/close_v_curtain.json
+++ b/sound/CC-Sounds/vehicle_close/v_curtain/close_v_curtain.json
@@ -3,5 +3,5 @@
         "id" : "vehicle_close",
         "variant" : "v_curtain",
         "volume" : 70,
-        "files" : [ "close_door/window/close_curtains.ogg" ]
+        "files" : [ "close_door/window/close_curtain.ogg" ]
 }

--- a/sound/CC-Sounds/vehicle_open/v_curtain/open_v_curtain.json
+++ b/sound/CC-Sounds/vehicle_open/v_curtain/open_v_curtain.json
@@ -3,5 +3,5 @@
         "id" : "vehicle_open",
         "variant" : "v_curtain",
         "volume" : 70,
-        "files" : [ "open_door/window/open_curtains.ogg" ]
+        "files" : [ "open_door/window/open_curtain.ogg" ]
 }


### PR DESCRIPTION
Fix  #22

Several sound files were referenced by wrong names. This was causing errors: "Tried to play a chunk with a bad frame"