### PR TITLE
GHA workflow to check sound file references / credits

### DIFF
--- a/.github/workflows/ref_check.yml
+++ b/.github/workflows/ref_check.yml
@@ -1,0 +1,14 @@
+name: Sound file reference check
+
+on: pull_request
+
+jobs:
+  field-check:
+    name: Sound file reference check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Run validation script
+      run: python3 tools/validate_unreferenced_sndfile.py sound/CC-Sounds/

--- a/.github/workflows/ref_check.yml
+++ b/.github/workflows/ref_check.yml
@@ -11,4 +11,4 @@ jobs:
       with:
         fetch-depth: 1
     - name: Run validation script
-      run: python3 tools/validate_unreferenced_sndfile.py sound/CC-Sounds/
+      run: python3 tools/validate_unreferenced_sndfile.py sound/CC-Sounds/ GHA

--- a/sound/CC-Sounds/close_door/window/credits.md
+++ b/sound/CC-Sounds/close_door/window/credits.md
@@ -1,4 +1,4 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
 | close_window.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** |  |
-| close_curtains.ogg | cmusounddesign (mix by Peter Havran Raven2236) | **CC-BY** | https://freesound.org/people/cmusounddesign/sounds/84708/ |
+| close_curtain.ogg | cmusounddesign (mix by Peter Havran Raven2236) | **CC-BY** | https://freesound.org/people/cmusounddesign/sounds/84708/ |

--- a/sound/CC-Sounds/environment/ambient/credits.md
+++ b/sound/CC-Sounds/environment/ambient/credits.md
@@ -1,10 +1,10 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| alarm | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| bells | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| daytime | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| indoors | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| nighttime | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| police_siren | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| underground | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| indoors | blouhond | **CC BY 3.0** | https://freesound.org/people/blouhond/sounds/163604/ |
+| alarm.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| bells.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| daytime.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| indoors.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| nighttime.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| police_siren.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| underground.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| indoors.ogg | blouhond | **CC BY 3.0** | https://freesound.org/people/blouhond/sounds/163604/ |

--- a/sound/CC-Sounds/environment/weather/credits.md
+++ b/sound/CC-Sounds/environment/weather/credits.md
@@ -5,7 +5,12 @@
 | flurries.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
 | heavyrain.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
 | snowing.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| thunder_far_1-4.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| thunder_near_1-3.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| thunder_far_1.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| thunder_far_2.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| thunder_far_3.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| thunder_far_4.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| thunder_near_1.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| thunder_near_2.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| thunder_near_3.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
 | thunderstorm.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
 | WEATHER_SNOWSTORM.ogg | guyburns | **CC 0** | https://freesound.org/people/guyburns/sounds/473815/ |

--- a/sound/CC-Sounds/environment/weather/weather_clear/credits.md
+++ b/sound/CC-Sounds/environment/weather/weather_clear/credits.md
@@ -1,6 +1,6 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| weather_clear_spring | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| weather_clear_summer | klankbeeld | **CC BY 3.0** | https://freesound.org/people/klankbeeld/sounds/436105/ |
-| weather_clear_autumn | Mountain852 | **CC BY-NC 3.0** | https://freesound.org/people/Mountain852/sounds/365821/ |
-| weather_clear_winter | matucha | **CC BY-NC 3.0** | https://freesound.org/people/matucha/sounds/192139/ |
+| weather_clear_spring.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| weather_clear_summer.ogg | klankbeeld | **CC BY 3.0** | https://freesound.org/people/klankbeeld/sounds/436105/ |
+| weather_clear_autumn.ogg | Mountain852 | **CC BY-NC 3.0** | https://freesound.org/people/Mountain852/sounds/365821/ |
+| weather_clear_winter.ogg | matucha | **CC BY-NC 3.0** | https://freesound.org/people/matucha/sounds/192139/ |

--- a/sound/CC-Sounds/environment/weather/weather_cloudy/credits.md
+++ b/sound/CC-Sounds/environment/weather/weather_cloudy/credits.md
@@ -1,6 +1,6 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| weather_cloudy_spring | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
-| weather_cloudy_autumn | Apostolinkyyti | **CC0 1.0** | https://freesound.org/people/Apostolinkyyti/sounds/128940/ |
-| weather_cloudy_winter | klankbeeld | **CC BY 3.0** | https://freesound.org/people/klankbeeld/sounds/339699/ |
-| weather_cloudy_summer | klankbeeld | **CC BY 3.0** | https://freesound.org/people/klankbeeld/sounds/507383/ |
+| weather_cloudy_spring.ogg | Peter Havran (Raven 2236) | **CC BY-NC-SA 2.0** | |
+| weather_cloudy_autumn.ogg | Apostolinkyyti | **CC0 1.0** | https://freesound.org/people/Apostolinkyyti/sounds/128940/ |
+| weather_cloudy_winter.ogg | klankbeeld | **CC BY 3.0** | https://freesound.org/people/klankbeeld/sounds/339699/ |
+| weather_cloudy_summer.ogg | klankbeeld | **CC BY 3.0** | https://freesound.org/people/klankbeeld/sounds/507383/ |

--- a/sound/CC-Sounds/environment/weather/weather_sunny/credits.md
+++ b/sound/CC-Sounds/environment/weather/weather_sunny/credits.md
@@ -1,6 +1,6 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| weather_sunny_spring | Modding | **CC0 1.0** | https://freesound.org/people/Modding/sounds/574108/ |
-| weather_sunny_autumn | dobroide | **CC BY 3.0** | https://freesound.org/people/dobroide/sounds/26254/ |
-| weather_sunny_winter | klankbeeld | **CC BY 3.0** | https://freesound.org/people/klankbeeld/sounds/337083/ |
-| weather_sunny_summer | klankbeeld | **CC BY 3.0** | https://freesound.org/people/klankbeeld/sounds/475943/ |
+| weather_sunny_spring.ogg | Modding | **CC0 1.0** | https://freesound.org/people/Modding/sounds/574108/ |
+| weather_sunny_autumn.ogg | dobroide | **CC BY 3.0** | https://freesound.org/people/dobroide/sounds/26254/ |
+| weather_sunny_winter.ogg | klankbeeld | **CC BY 3.0** | https://freesound.org/people/klankbeeld/sounds/337083/ |
+| weather_sunny_summer.ogg | klankbeeld | **CC BY 3.0** | https://freesound.org/people/klankbeeld/sounds/475943/ |

--- a/sound/CC-Sounds/gun/shotguns/credits.md
+++ b/sound/CC-Sounds/gun/shotguns/credits.md
@@ -1,3 +1,3 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| Shotgun_1.ogg    | MATRIXXX_ |**CC-BY**  | https://freesound.org/people/MATRIXXX_/sounds/473846/ |
+| shotgun_1.ogg    | MATRIXXX_ |**CC-BY**  | https://freesound.org/people/MATRIXXX_/sounds/473846/ |

--- a/sound/CC-Sounds/melee_hit_flesh/big_bash/credits.md
+++ b/sound/CC-Sounds/melee_hit_flesh/big_bash/credits.md
@@ -1,4 +1,4 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| big_bash_flesh_1 | SilverIllusionist | **CC BY 3.0** | https://freesound.org/people/SilverIllusionist/sounds/470587/ |
-| big_bash_flesh_2 | original_sound | **CC BY 3.0** | https://freesound.org/people/original_sound/sounds/376818/ |
+| big_bash_flesh_1.ogg | SilverIllusionist | **CC BY 3.0** | https://freesound.org/people/SilverIllusionist/sounds/470587/ |
+| big_bash_flesh_2.ogg | original_sound | **CC BY 3.0** | https://freesound.org/people/original_sound/sounds/376818/ |

--- a/sound/CC-Sounds/melee_hit_flesh/big_cutting/credits.md
+++ b/sound/CC-Sounds/melee_hit_flesh/big_cutting/credits.md
@@ -1,4 +1,4 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| big_cutting_flesh_1 | Aris621 | **CC BY 3.0** | https://freesound.org/people/Aris621/sounds/478145/ |
-| big_cutting_flesh_2 | Aris621 | **CC BY 3.0** | https://freesound.org/people/Aris621/sounds/435238/ |
+| big_cutting_flesh_1.ogg | Aris621 | **CC BY 3.0** | https://freesound.org/people/Aris621/sounds/478145/ |
+| big_cutting_flesh_2.ogg | Aris621 | **CC BY 3.0** | https://freesound.org/people/Aris621/sounds/435238/ |

--- a/sound/CC-Sounds/melee_hit_flesh/big_stabbing/credits.md
+++ b/sound/CC-Sounds/melee_hit_flesh/big_stabbing/credits.md
@@ -1,5 +1,5 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| big_stabbing_flesh_1 | magnuswaker | **CC0** | https://freesound.org/people/magnuswaker/sounds/522091/ |
-| big_stabbing_flesh_2 | magnuswaker | **CC0** | https://freesound.org/people/magnuswaker/sounds/528263/ |
-| big_stabbing_flesh_3 | magnuswaker | **CC0** | https://freesound.org/people/magnuswaker/sounds/530117/ |
+| big_stabbing_flesh_1.ogg | magnuswaker | **CC0** | https://freesound.org/people/magnuswaker/sounds/522091/ |
+| big_stabbing_flesh_2.ogg | magnuswaker | **CC0** | https://freesound.org/people/magnuswaker/sounds/528263/ |
+| big_stabbing_flesh_3.ogg | magnuswaker | **CC0** | https://freesound.org/people/magnuswaker/sounds/530117/ |

--- a/sound/CC-Sounds/melee_hit_flesh/default/credits.md
+++ b/sound/CC-Sounds/melee_hit_flesh/default/credits.md
@@ -1,3 +1,7 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| unarmed_hit_flesh 1 to 5 | deleted_user_7146007 | **CC0** | https://freesound.org/people/deleted_user_7146007/sounds/383882/ |
+| unarmed_hit_flesh_1.ogg | deleted_user_7146007 | **CC0** | https://freesound.org/people/deleted_user_7146007/sounds/383882/ |
+| unarmed_hit_flesh_2.ogg | deleted_user_7146007 | **CC0** | https://freesound.org/people/deleted_user_7146007/sounds/383882/ |
+| unarmed_hit_flesh_3.ogg | deleted_user_7146007 | **CC0** | https://freesound.org/people/deleted_user_7146007/sounds/383882/ |
+| unarmed_hit_flesh_4.ogg | deleted_user_7146007 | **CC0** | https://freesound.org/people/deleted_user_7146007/sounds/383882/ |
+| unarmed_hit_flesh_5.ogg | deleted_user_7146007 | **CC0** | https://freesound.org/people/deleted_user_7146007/sounds/383882/ |

--- a/sound/CC-Sounds/melee_hit_flesh/small_bash/credits.md
+++ b/sound/CC-Sounds/melee_hit_flesh/small_bash/credits.md
@@ -1,3 +1,6 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| small_bash_flesh 1 to 4 | mateusboga | **CC0** | https://freesound.org/people/mateusboga/sounds/426065/ |
+| small_bash_flesh_1.ogg | mateusboga | **CC0** | https://freesound.org/people/mateusboga/sounds/426065/ |
+| small_bash_flesh_2.ogg | mateusboga | **CC0** | https://freesound.org/people/mateusboga/sounds/426065/ |
+| small_bash_flesh_3.ogg | mateusboga | **CC0** | https://freesound.org/people/mateusboga/sounds/426065/ |
+| small_bash_flesh_4.ogg | mateusboga | **CC0** | https://freesound.org/people/mateusboga/sounds/426065/ |

--- a/sound/CC-Sounds/melee_hit_flesh/small_cutting/credits.md
+++ b/sound/CC-Sounds/melee_hit_flesh/small_cutting/credits.md
@@ -1,5 +1,5 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| small_cutting_flesh_1 | EminYILDIRIM | **CC BY 3.0** | https://freesound.org/people/EminYILDIRIM/sounds/554284/ |
-| small_cutting_flesh_2 | Mixedupmoviestuff | **CC0** | https://freesound.org/people/Mixedupmoviestuff/sounds/179222/ |
-| small_cutting_flesh_3 | LittleRobotSoundFactory | **CC BY 3.0** | https://freesound.org/people/LittleRobotSoundFactory/sounds/270478/ |
+| small_cutting_flesh_1.ogg | EminYILDIRIM | **CC BY 3.0** | https://freesound.org/people/EminYILDIRIM/sounds/554284/ |
+| small_cutting_flesh_2.ogg | Mixedupmoviestuff | **CC0** | https://freesound.org/people/Mixedupmoviestuff/sounds/179222/ |
+| small_cutting_flesh_3.ogg | LittleRobotSoundFactory | **CC BY 3.0** | https://freesound.org/people/LittleRobotSoundFactory/sounds/270478/ |

--- a/sound/CC-Sounds/melee_hit_flesh/small_stabbing/credits.md
+++ b/sound/CC-Sounds/melee_hit_flesh/small_stabbing/credits.md
@@ -1,3 +1,8 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| small_stabbing_flesh 1 to 6 | Podcapocalipsis | **CC0** | https://freesound.org/people/Podcapocalipsis/sounds/521030/ |
+| small_stabbing_flesh_1.ogg | Podcapocalipsis | **CC0** | https://freesound.org/people/Podcapocalipsis/sounds/521030/ |
+| small_stabbing_flesh_2.ogg | Podcapocalipsis | **CC0** | https://freesound.org/people/Podcapocalipsis/sounds/521030/ |
+| small_stabbing_flesh_3.ogg | Podcapocalipsis | **CC0** | https://freesound.org/people/Podcapocalipsis/sounds/521030/ |
+| small_stabbing_flesh_4.ogg | Podcapocalipsis | **CC0** | https://freesound.org/people/Podcapocalipsis/sounds/521030/ |
+| small_stabbing_flesh_5.ogg | Podcapocalipsis | **CC0** | https://freesound.org/people/Podcapocalipsis/sounds/521030/ |
+| small_stabbing_flesh_6.ogg | Podcapocalipsis | **CC0** | https://freesound.org/people/Podcapocalipsis/sounds/521030/ |

--- a/sound/CC-Sounds/melee_swing/big_bash/credits.md
+++ b/sound/CC-Sounds/melee_swing/big_bash/credits.md
@@ -1,3 +1,3 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| big_bash_swing_1 | orangesheepdog | **CC0** | https://freesound.org/people/orangesheepdog/sounds/367182/ |
+| big_bash_swing_1.ogg | orangesheepdog | **CC0** | https://freesound.org/people/orangesheepdog/sounds/367182/ |

--- a/sound/CC-Sounds/melee_swing/big_cutting/credits.md
+++ b/sound/CC-Sounds/melee_swing/big_cutting/credits.md
@@ -1,3 +1,3 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| big_cutting_swing_1 | qubodup | **CC0** | https://freesound.org/people/qubodup/sounds/59992/ |
+| big_cutting_swing_1.ogg | qubodup | **CC0** | https://freesound.org/people/qubodup/sounds/59992/ |

--- a/sound/CC-Sounds/melee_swing/big_stabbing/credits.md
+++ b/sound/CC-Sounds/melee_swing/big_stabbing/credits.md
@@ -1,3 +1,3 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| big_stabbing_swing_1 | Danjocross | **CC0** | https://freesound.org/people/Danjocross/sounds/507466/ |
+| big_stabbing_swing_1.ogg | Danjocross | **CC0** | https://freesound.org/people/Danjocross/sounds/507466/ |

--- a/sound/CC-Sounds/melee_swing/default/credits.md
+++ b/sound/CC-Sounds/melee_swing/default/credits.md
@@ -1,7 +1,7 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| unarmed_swing_1 | Joao_Janz | **CC BY-NC 3.0** | https://freesound.org/people/Joao_Janz/sounds/485268/ |
-| unarmed_swing_2 | Joao_Janz | **CC BY-NC 3.0** | https://freesound.org/people/Joao_Janz/sounds/485258/ |
-| unarmed_swing_3 | Joao_Janz | **CC BY-NC 3.0** | https://freesound.org/people/Joao_Janz/sounds/485252/ |
-| unarmed_swing_4 | Joao_Janz | **CC BY-NC 3.0** | https://freesound.org/people/Joao_Janz/sounds/485272/ |
-| unarmed_swing_5 | Joao_Janz | **CC BY-NC 3.0** | https://freesound.org/people/Joao_Janz/sounds/485273/ |
+| unarmed_swing_1.ogg | Joao_Janz | **CC BY-NC 3.0** | https://freesound.org/people/Joao_Janz/sounds/485268/ |
+| unarmed_swing_2.ogg | Joao_Janz | **CC BY-NC 3.0** | https://freesound.org/people/Joao_Janz/sounds/485258/ |
+| unarmed_swing_3.ogg | Joao_Janz | **CC BY-NC 3.0** | https://freesound.org/people/Joao_Janz/sounds/485252/ |
+| unarmed_swing_4.ogg | Joao_Janz | **CC BY-NC 3.0** | https://freesound.org/people/Joao_Janz/sounds/485272/ |
+| unarmed_swing_5.ogg | Joao_Janz | **CC BY-NC 3.0** | https://freesound.org/people/Joao_Janz/sounds/485273/ |

--- a/sound/CC-Sounds/melee_swing/small_bash/credits.md
+++ b/sound/CC-Sounds/melee_swing/small_bash/credits.md
@@ -1,3 +1,9 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| small_bash_swing 1 to 7 | Danjocross | **CC0** | https://freesound.org/people/Danjocross/sounds/507470/ |
+| small_bash_swing_1.ogg | Danjocross | **CC0** | https://freesound.org/people/Danjocross/sounds/507470/ |
+| small_bash_swing_2.ogg | Danjocross | **CC0** | https://freesound.org/people/Danjocross/sounds/507470/ |
+| small_bash_swing_3.ogg | Danjocross | **CC0** | https://freesound.org/people/Danjocross/sounds/507470/ |
+| small_bash_swing_4.ogg | Danjocross | **CC0** | https://freesound.org/people/Danjocross/sounds/507470/ |
+| small_bash_swing_5.ogg | Danjocross | **CC0** | https://freesound.org/people/Danjocross/sounds/507470/ |
+| small_bash_swing_6.ogg | Danjocross | **CC0** | https://freesound.org/people/Danjocross/sounds/507470/ |
+| small_bash_swing_7.ogg | Danjocross | **CC0** | https://freesound.org/people/Danjocross/sounds/507470/ |

--- a/sound/CC-Sounds/melee_swing/small_cutting/credits.md
+++ b/sound/CC-Sounds/melee_swing/small_cutting/credits.md
@@ -1,3 +1,8 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| small_cutting_swing 1 to 6 | MoveAwayPodcast | **CC BY 3.0** | https://freesound.org/people/MoveAwayPodcast/sounds/555732/ |
+| small_cutting_swing_1.ogg | MoveAwayPodcast | **CC BY 3.0** | https://freesound.org/people/MoveAwayPodcast/sounds/555732/ |
+| small_cutting_swing_2.ogg | MoveAwayPodcast | **CC BY 3.0** | https://freesound.org/people/MoveAwayPodcast/sounds/555732/ |
+| small_cutting_swing_3.ogg | MoveAwayPodcast | **CC BY 3.0** | https://freesound.org/people/MoveAwayPodcast/sounds/555732/ |
+| small_cutting_swing_4.ogg | MoveAwayPodcast | **CC BY 3.0** | https://freesound.org/people/MoveAwayPodcast/sounds/555732/ |
+| small_cutting_swing_5.ogg | MoveAwayPodcast | **CC BY 3.0** | https://freesound.org/people/MoveAwayPodcast/sounds/555732/ |
+| small_cutting_swing_6.ogg | MoveAwayPodcast | **CC BY 3.0** | https://freesound.org/people/MoveAwayPodcast/sounds/555732/ |

--- a/sound/CC-Sounds/melee_swing/small_stabbing/credits.md
+++ b/sound/CC-Sounds/melee_swing/small_stabbing/credits.md
@@ -1,3 +1,6 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| small_stabbing_swing 1 to 4 | PorkMuncher | **CC0** | https://freesound.org/people/PorkMuncher/sounds/263595/ |
+| small_stabbing_swing_1.ogg | PorkMuncher | **CC0** | https://freesound.org/people/PorkMuncher/sounds/263595/ |
+| small_stabbing_swing_2.ogg | PorkMuncher | **CC0** | https://freesound.org/people/PorkMuncher/sounds/263595/ |
+| small_stabbing_swing_3.ogg | PorkMuncher | **CC0** | https://freesound.org/people/PorkMuncher/sounds/263595/ |
+| small_stabbing_swing_4.ogg | PorkMuncher | **CC0** | https://freesound.org/people/PorkMuncher/sounds/263595/ |

--- a/sound/CC-Sounds/menu_move/credits.md
+++ b/sound/CC-Sounds/menu_move/credits.md
@@ -1,3 +1,3 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| menu_move.wav | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** | |
+| menu_move.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** | |

--- a/sound/CC-Sounds/mon_death/zombie_death/credits.md
+++ b/sound/CC-Sounds/mon_death/zombie_death/credits.md
@@ -1,6 +1,6 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| zombie_death_1 | missozzy   | **CC-BY** | https://freesound.org/people/missozzy/sounds/169841/ |
-| zombie_death_2 | LittleRobotSoundFactory  | **CC-BY**   | https://freesound.org/people/LittleRobotSoundFactory/sounds/316208/ |
-| zombie_death_3 | Joao_Janz  | **CC-BY-NC 3.0**   | https://freesound.org/people/Joao_Janz/sounds/483790/ |
-| zombie_death_4 | tonsil5  | **CC0**   | https://freesound.org/people/tonsil5/sounds/555412/ |
+| zombie_death_1.ogg | missozzy   | **CC-BY** | https://freesound.org/people/missozzy/sounds/169841/ |
+| zombie_death_2.ogg | LittleRobotSoundFactory  | **CC-BY**   | https://freesound.org/people/LittleRobotSoundFactory/sounds/316208/ |
+| zombie_death_3.ogg | Joao_Janz  | **CC-BY-NC 3.0**   | https://freesound.org/people/Joao_Janz/sounds/483790/ |
+| zombie_death_4.ogg | tonsil5  | **CC0**   | https://freesound.org/people/tonsil5/sounds/555412/ |

--- a/sound/CC-Sounds/mon_death/zombie_gibbed/credits.md
+++ b/sound/CC-Sounds/mon_death/zombie_gibbed/credits.md
@@ -1,4 +1,4 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| zombie_gibbed_1 | PaulMorek   | **CC0** | https://freesound.org/people/PaulMorek/sounds/196725/ |
-| zombie_gibbed_2 | Audionautics  | **CC-BY**   | https://freesound.org/people/Audionautics/sounds/133968/ |
+| zombie_gibbed_1.ogg | PaulMorek   | **CC0** | https://freesound.org/people/PaulMorek/sounds/196725/ |
+| zombie_gibbed_2.ogg | Audionautics  | **CC-BY**   | https://freesound.org/people/Audionautics/sounds/133968/ |

--- a/sound/CC-Sounds/open_door/window/credits.md
+++ b/sound/CC-Sounds/open_door/window/credits.md
@@ -1,4 +1,4 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
 | open_window.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** |  |
-| open_curtains.ogg | cmusounddesign (mix by Peter Havran Raven 2236) | **CC-BY** | https://freesound.org/people/cmusounddesign/sounds/84708/ |
+| open_curtain.ogg | cmusounddesign (mix by Peter Havran Raven 2236) | **CC-BY** | https://freesound.org/people/cmusounddesign/sounds/84708/ |

--- a/sound/CC-Sounds/plmove/credits.md
+++ b/sound/CC-Sounds/plmove/credits.md
@@ -1,38 +1,117 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| walk_grass_1-7 | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
-| walk_dirt_1 | nuFF3 | **CC-BY** | https://freesound.org/s/477396/ |
-| walk_dirt_2 | nuFF3 | **CC-BY** | https://freesound.org/s/477395/ |
-| walk_dirt_3 | nuFF3 | **CC-BY** | https://freesound.org/s/477394/ |
-| walk_dirt_4 | nuFF3 | **CC-BY** | https://freesound.org/s/477392/ |
-| walk_dirt_5 | nuFF3 | **CC-BY** | https://freesound.org/s/477391/ |
-| walk_dirt_6 | nuFF3 | **CC-BY** | https://freesound.org/s/477390/ |
-| walk_metal_1-9 | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
-| walk_barefoot 1 to 10 | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
-| walk_water 1 to 10 | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
-| clear_obstacle_1,5,6,7,8 | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
-| clear_obstacle_2 to 4 | MWsfx | **CC0** | https://freesound.org/s/574247/ |
-| walk_t_water_sh_1 | nathanaelj83 | **CC0** | https://freesound.org/s/145242/ |
-| walk_t_water_sh_2 | duckduckpony | **CC-BY** | https://freesound.org/s/204017/ |
-| walk_t_water_sh_3 | duckduckpony | **CC-BY** | https://freesound.org/s/204035/ |
-| walk_t_water_sh_4 | duckduckpony | **CC-BY** | https://freesound.org/s/204034/ |
-| walk_t_water_sh_5 | duckduckpony | **CC-BY** | https://freesound.org/s/204033/ |
-| walk_t_water_sh_6 | duckduckpony | **CC-BY** | https://freesound.org/s/204032/ |
-| walk_t_floor_1-14 | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
-| walk_t_rock_floor_1 | samulis | **CC0** | https://freesound.org/s/197781/ |
-| walk_t_rock_floor_2 | samulis | **CC0** | https://freesound.org/s/197780/ |
-| walk_t_rock_floor_3 | samulis | **CC0** | https://freesound.org/s/197779/ |
-| walk_t_rock_floor_4 | samulis | **CC0** | https://freesound.org/s/197778/ |
-| walk_t_carpet_1-8 | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
-| walk_t_gravel_10 | ali-6868 | **CC0** | https://freesound.org/s/384880/ |
-| walk_t_gravel_9 | ali-6868 | **CC0** | https://freesound.org/s/384879/ |
-| walk_t_gravel_8 | ali-6868 | **CC0** | https://freesound.org/s/384878/ |
-| walk_t_gravel_7 | ali-6868 | **CC0** | https://freesound.org/s/384877/ |
-| walk_t_gravel_6 | ali-6868 | **CC0** | https://freesound.org/s/384876/ |
-| walk_t_gravel_5 | ali-6868 | **CC0** | https://freesound.org/s/384875/ |
-| walk_t_gravel_4 | ali-6868 | **CC0** | https://freesound.org/s/384874/ |
-| walk_t_gravel_3 | ali-6868 | **CC0** | https://freesound.org/s/384873/ |
-| walk_t_gravel_2 | ali-6868 | **CC0** | https://freesound.org/s/384872/ |
-| walk_t_gravel_1 | ali-6868 | **CC0** | https://freesound.org/s/384871/ |
-| walk_t_concrete 1 to 10 | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
-| walk_t_grass_long_1-13 | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_grass_1.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_grass_2.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_grass_3.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_grass_4.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_grass_5.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_grass_6.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_grass_7.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_dirt_1.ogg | nuFF3 | **CC-BY** | https://freesound.org/s/477396/ |
+| walk_dirt_2.ogg | nuFF3 | **CC-BY** | https://freesound.org/s/477395/ |
+| walk_dirt_3.ogg | nuFF3 | **CC-BY** | https://freesound.org/s/477394/ |
+| walk_dirt_4.ogg | nuFF3 | **CC-BY** | https://freesound.org/s/477392/ |
+| walk_dirt_5.ogg | nuFF3 | **CC-BY** | https://freesound.org/s/477391/ |
+| walk_dirt_6.ogg | nuFF3 | **CC-BY** | https://freesound.org/s/477390/ |
+| walk_metal_1.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_metal_2.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_metal_3.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_metal_4.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_metal_5.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_metal_6.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_metal_7.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_metal_8.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_metal_9.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_barefoot_1.ogg | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
+| walk_barefoot_2.ogg | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
+| walk_barefoot_3.ogg | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
+| walk_barefoot_4.ogg | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
+| walk_barefoot_5.ogg | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
+| walk_barefoot_6.ogg | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
+| walk_barefoot_7.ogg | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
+| walk_barefoot_8.ogg | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
+| walk_barefoot_9.ogg | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
+| walk_barefoot_10.ogg | SpliceSound | **CC0** | https://freesound.org/s/338106/ |
+| walk_water_1.ogg | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
+| walk_water_2.ogg | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
+| walk_water_3.ogg | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
+| walk_water_4.ogg | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
+| walk_water_5.ogg | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
+| walk_water_6.ogg | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
+| walk_water_7.ogg | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
+| walk_water_8.ogg | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
+| walk_water_9.ogg | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
+| walk_water_10.ogg | dawidwmika | **CC0** | https://freesound.org/s/372518/ |
+| clear_obstacle_1.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| clear_obstacle_5.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| clear_obstacle_6.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| clear_obstacle_7.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| clear_obstacle_8.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| clear_obstacle_2.ogg | MWsfx | **CC0** | https://freesound.org/s/574247/ |
+| clear_obstacle_3.ogg | MWsfx | **CC0** | https://freesound.org/s/574247/ |
+| clear_obstacle_4.ogg | MWsfx | **CC0** | https://freesound.org/s/574247/ |
+| walk_t_water_sh_1.ogg | nathanaelj83 | **CC0** | https://freesound.org/s/145242/ |
+| walk_t_water_sh_2.ogg | duckduckpony | **CC-BY** | https://freesound.org/s/204017/ |
+| walk_t_water_sh_3.ogg | duckduckpony | **CC-BY** | https://freesound.org/s/204035/ |
+| walk_t_water_sh_4.ogg | duckduckpony | **CC-BY** | https://freesound.org/s/204034/ |
+| walk_t_water_sh_5.ogg | duckduckpony | **CC-BY** | https://freesound.org/s/204033/ |
+| walk_t_water_sh_6.ogg | duckduckpony | **CC-BY** | https://freesound.org/s/204032/ |
+| walk_t_floor_1.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_2.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_3.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_4.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_5.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_6.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_7.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_8.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_9.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_10.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_11.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_12.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_13.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_floor_14.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_rock_floor_1.ogg | samulis | **CC0** | https://freesound.org/s/197781/ |
+| walk_t_rock_floor_2.ogg | samulis | **CC0** | https://freesound.org/s/197780/ |
+| walk_t_rock_floor_3.ogg | samulis | **CC0** | https://freesound.org/s/197779/ |
+| walk_t_rock_floor_4.ogg | samulis | **CC0** | https://freesound.org/s/197778/ |
+| walk_t_carpet_1.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_carpet_2.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_carpet_3.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_carpet_4.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_carpet_5.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_carpet_6.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_carpet_7.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_carpet_8.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_gravel_10.ogg | ali-6868 | **CC0** | https://freesound.org/s/384880/ |
+| walk_t_gravel_9.ogg | ali-6868 | **CC0** | https://freesound.org/s/384879/ |
+| walk_t_gravel_8.ogg | ali-6868 | **CC0** | https://freesound.org/s/384878/ |
+| walk_t_gravel_7.ogg | ali-6868 | **CC0** | https://freesound.org/s/384877/ |
+| walk_t_gravel_6.ogg | ali-6868 | **CC0** | https://freesound.org/s/384876/ |
+| walk_t_gravel_5.ogg | ali-6868 | **CC0** | https://freesound.org/s/384875/ |
+| walk_t_gravel_4.ogg | ali-6868 | **CC0** | https://freesound.org/s/384874/ |
+| walk_t_gravel_3.ogg | ali-6868 | **CC0** | https://freesound.org/s/384873/ |
+| walk_t_gravel_2.ogg | ali-6868 | **CC0** | https://freesound.org/s/384872/ |
+| walk_t_gravel_1.ogg | ali-6868 | **CC0** | https://freesound.org/s/384871/ |
+| walk_t_concrete_1.ogg | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
+| walk_t_concrete_2.ogg | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
+| walk_t_concrete_3.ogg | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
+| walk_t_concrete_4.ogg | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
+| walk_t_concrete_5.ogg | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
+| walk_t_concrete_6.ogg | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
+| walk_t_concrete_7.ogg | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
+| walk_t_concrete_8.ogg | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
+| walk_t_concrete_9.ogg | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
+| walk_t_concrete_10.ogg | InspectorJ| **CC-BY** | https://freesound.org/s/336598/ |
+| walk_t_grass_long_1.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_2.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_3.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_4.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_5.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_6.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_7.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_8.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_9.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_10.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_11.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_12.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||
+| walk_t_grass_long_13.ogg | Peter Havran (Raven2236) | **CC BY-NC-SA 2.0** ||

--- a/sound/CC-Sounds/smash_success/hit_vehicle/credits.md
+++ b/sound/CC-Sounds/smash_success/hit_vehicle/credits.md
@@ -1,3 +1,6 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| hit_vehicle (1, 2, 3 & 4) .ogg | Halleck | **CC-BY** | https://freesound.org/people/Halleck/sounds/121621/ |
+| hit_vehicle1.ogg | Halleck | **CC-BY** | https://freesound.org/people/Halleck/sounds/121621/ |
+| hit_vehicle2.ogg | Halleck | **CC-BY** | https://freesound.org/people/Halleck/sounds/121621/ |
+| hit_vehicle3.ogg | Halleck | **CC-BY** | https://freesound.org/people/Halleck/sounds/121621/ |
+| hit_vehicle4.ogg | Halleck | **CC-BY** | https://freesound.org/people/Halleck/sounds/121621/ |

--- a/sound/CC-Sounds/vehicle/gear_shift/credits.md
+++ b/sound/CC-Sounds/vehicle/gear_shift/credits.md
@@ -1,3 +1,5 @@
 | File Name        | Author   | License   | Link                            |
 |------------------|----------|-----------|---------------------------------|
-| gear_shift (1, 2 & 3) .ogg | JaimeLopes | **CC-BY** | https://freesound.org/people/JaimeLopes/sounds/442766/ |
+| gear_shift1.ogg | JaimeLopes | **CC-BY** | https://freesound.org/people/JaimeLopes/sounds/442766/ |
+| gear_shift2.ogg | JaimeLopes | **CC-BY** | https://freesound.org/people/JaimeLopes/sounds/442766/ |
+| gear_shift3.ogg | JaimeLopes | **CC-BY** | https://freesound.org/people/JaimeLopes/sounds/442766/ |

--- a/tools/validate_unreferenced_sndfile.py
+++ b/tools/validate_unreferenced_sndfile.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+
+args = argparse.ArgumentParser()
+args.add_argument("dir", action="store", help="specify json directory")
+args_dict = vars(args.parse_args())
+
+
+snd_exts = {
+    ".ogg",
+    ".wav",
+    ".mp3",
+    ".aac",
+    ".opus",
+    ".flac",
+    ".midi",
+    ".aax",
+    ".m4a",
+    ".bnk",
+    ".wma",
+    ".aiff",
+    ".raw",
+    ".fla",
+    ".mpa",
+    ".oga",
+    ".m3a",
+    ".aif",
+    ".mpega"
+}
+
+
+def find_obj_ref(sndfile, jo) -> bool:
+    if "type" in jo:
+        if jo["type"] == "playlist" and "playlists" in jo:
+            for pl in jo["playlists"]:
+                if "files" in pl:
+                    for file in pl["files"]:
+                        if file["file"] == sndfile:
+                            return True
+        if jo["type"] == "sound_effect" and "files" in jo:
+            for file in jo["files"]:
+                if file == sndfile:
+                    return True
+    return False
+
+
+def find_ref(sndfile, jsonfile) -> bool:
+    with open(jsonfile, "r", encoding="utf-8") as json_file:
+        jdata = json.load(json_file)
+        for jo in jdata:
+            if type(jo) is not dict:
+                if find_obj_ref(sndfile, jdata):
+                    return True
+                break
+            if find_obj_ref(sndfile, jo):
+                return True
+    return False
+
+
+def match_file(path) -> bool:
+    for root, dirs, filenames in os.walk(args_dict["dir"]):
+        for filename in filenames:
+            json_file = os.path.join(root, filename)
+            if json_file.endswith(".json"):
+                if find_ref(path, json_file):
+                    print(" + Found reference in {}".format(json_file))
+                    return True
+    print(" - Error: No JSON reference for sound file {}".format(path),
+          file=sys.stderr)
+    return False
+
+
+def check_credits(path) -> bool:
+    fname = path.split("/").pop()
+    for root, dirs, filenames in os.walk(args_dict["dir"]):
+        for filename in filenames:
+            if filename.lower() in { "credits.md", "credits.txt" }:
+                cred_file = os.path.join(root, filename)
+                with open(cred_file, "r", encoding="utf-8") as credata:
+                    if fname in credata.read():
+                        print(" + Found credit entry for \"{}\" in {}"
+                              .format(fname, cred_file))
+                        return True
+    print(" - Error: No credits entry for \"{}\"".format(fname))
+    return False
+
+
+retval = 0
+at_least_one = False
+
+for root, dirs, filenames in os.walk(args_dict["dir"]):
+    for filename in filenames:
+        path = os.path.join(root, filename)
+        ext = os.path.splitext(filename)
+        if ext[1].lower() in snd_exts:
+            at_least_one = True
+            shortpath = path.split(args_dict["dir"]).pop()
+            print("\nSearching for references to {} ...".format(shortpath))
+            if not match_file(shortpath):
+                retval = 1
+            if not check_credits(shortpath):
+                retval = 1
+
+if at_least_one == False:
+    print("Error: No sound files processed", file=sys.stderr)
+    retval = 1
+
+sys.exit(retval)


### PR DESCRIPTION
Contributes to #29.

Adds a workflow to verify that:
- each sound file is referenced in at least one sound_effect / playlist
- each sound file has an entry in a credits file

Demo:
Failed run (unmatched credit entries): https://github.com/dseguin/CDDA-Soundpacks/runs/5507624302
Successful run (fixed credits): https://github.com/dseguin/CDDA-Soundpacks/runs/5507639321