### PR TITLE
Fixes issue 79, adds missing sound entries to all types of wooden doors

### DIFF
--- a/sound/CC-Sounds/close_door/door_wood/close_door.json
+++ b/sound/CC-Sounds/close_door/door_wood/close_door.json
@@ -5,5 +5,54 @@
     "variant": "t_door_o",
     "volume": 70,
     "files": [ "close_door/door_wood/close_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "close_door",
+    "variant": "t_door_red_o",
+    "volume": 70,
+    "files": [ "close_door/door_wood/close_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "close_door",
+    "variant": "t_door_white_o",
+    "volume": 70,
+    "files": [ "close_door/door_wood/close_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "close_door",
+    "variant": "t_door_gray_o",
+    "volume": 70,
+    "files": [ "close_door/door_wood/close_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "close_door",
+    "variant": "t_door_green_o",
+    "volume": 70,
+    "files": [ "close_door/door_wood/close_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "close_door",
+    "variant": "t_door_lab_o",
+    "volume": 70,
+    "files": [ "close_door/door_wood/close_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "close_door",
+    "variant": "t_door_o_peep",
+    "volume": 70,
+    "files": [ "close_door/door_wood/close_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "close_door",
+    "variant": "t_rdoor_o",
+    "volume": 70,
+    "files": [ "close_door/door_wood/close_door.ogg" ]
   }
 ]

--- a/sound/CC-Sounds/open_door/door_wood/open_door.json
+++ b/sound/CC-Sounds/open_door/door_wood/open_door.json
@@ -96,5 +96,12 @@
     "variant": "t_door_locked_alarm",
     "volume": 80,
     "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_rdoor_c",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
   }
 ]

--- a/sound/CC-Sounds/open_door/door_wood/open_door.json
+++ b/sound/CC-Sounds/open_door/door_wood/open_door.json
@@ -5,5 +5,96 @@
     "variant": "t_door_c",
     "volume": 80,
     "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_elocked",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_elocked_peep",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_elocked_alarm",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_lab_c",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_white_c",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_gray_c",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_red_c",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_green_c",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_c_peep",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "t_door_locked_interior",
+    "variant": "t_door_c_peep",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_locked",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_locked_peep",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "open_door",
+    "variant": "t_door_locked_alarm",
+    "volume": 80,
+    "files": [ "open_door/door_wood/open_door.ogg" ]
   }
 ]


### PR DESCRIPTION
This PR fixes issue #79, which reported that not all wooden doors were playing the appropriate sound properly. The reason for this was that, in the soundpack itself, only t_door_o and t_door_c were assigned sounds. In the game files proper, there are about (by my very scientific calculations) 4 billion different door variants. Why do doors t_door_gray, t_door_red, and t_door_green exist? That is a question I cannot answer. I simply jumped into the JSON, added sound file entries for all the open and closed wood door variants I could find, and hoped I pushed the right buttons to fix the issue.
These changes have not been tested, as I’m blind. No version of the game that’s capable of using soundpacks is usable by the blind. Ergo, I cannot test my fix. Also, on a side note, the same issue reported in #79 likely extends across all other types of doors, so they’ll have to be given the same treatment in a future PR.
